### PR TITLE
Revert "Bump werkzeug from 2.3.7 to 3.0.0 in /src"

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -7,4 +7,4 @@ python-dotenv==1.0.0
 bcrypt==4.0.1
 couchbase==4.1.8
 six==1.16.0
-Werkzeug==3.0.0
+Werkzeug==2.3.7


### PR DESCRIPTION
Reverts couchbase-examples/python-quickstart#81