### PR TITLE
Refresh Python quickstart for Python 3.12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,11 +20,13 @@ jobs:
         run: |
           apt update || echo "apt-update failed" # && apt -y upgrade
       - uses: actions/checkout@v3
-      - name: Setup Python
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Setup Python dependencies
         run: |
-          sudo apt -y update
-          sudo apt -y install python3-pip python3-testresources
           cd src
+          python -m pip install --upgrade pip
           python -m pip install -r requirements.txt
       - name: Setup app
         run: |

--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ To run this prebuilt project, you will need:
 
 - [Couchbase Capella](https://www.couchbase.com/products/capella/) cluster with [travel-sample](https://docs.couchbase.com/python-sdk/current/ref/travel-app-data-model.html) bucket loaded.
   - To run this tutorial using a self managed Couchbase cluster, please refer to the [appendix](#running-self-managed-couchbase-cluster).
-- [Python](https://www.python.org/downloads/) 3.12 or higher installed
-  - This quickstart is verified in CI and locally with Python 3.12.
+- [Python](https://www.python.org/downloads/) 3.10 or higher installed
   - Ensure that the Python version is [compatible](https://docs.couchbase.com/python-sdk/current/project-docs/compatibility.html#python-version-compat) with the Couchbase SDK.
 - Loading Travel Sample Bucket
   If travel-sample is not loaded in your Capella cluster, you can load it by following the instructions for your Capella Cluster:
@@ -40,14 +39,14 @@ The dependencies for the application are specified in the `requirements.txt` fil
 
 ```shell
 cd src
-python3 -m pip install -r requirements.txt
+python -m pip install -r requirements.txt
 ```
 
-> Note: On Windows, or inside an activated virtual environment where `python3` is not available, use `python` in the commands below instead.
+> Note: If your environment only provides a `python3` executable, substitute `python3` in the commands below.
 
 > Note: Python SDKs older than version 4.1.9 require OpenSSL v1.1. This might not be the default in some newer platforms. In such scenarios, please install the SDK without using the prebuilt wheels
 
-> `python3 -m pip install couchbase --no-binary couchbase`
+> `python -m pip install couchbase --no-binary couchbase`
 
 > Refer to the [instructions in the SDK](https://github.com/couchbase/couchbase-python-client#alternative-installation-methods) for more info.
 
@@ -80,7 +79,7 @@ At this point, we have installed the dependencies, loaded the travel-sample data
 
 ```sh
 cd src
-python3 app.py
+python app.py
 ```
 
 ### Using Docker
@@ -116,7 +115,7 @@ To run the integration tests, use the following commands:
 
 ```sh
 cd src
-python3 -m pytest
+python -m pytest
 ```
 
 ## Appendix

--- a/README.md
+++ b/README.md
@@ -43,9 +43,11 @@ cd src
 python3 -m pip install -r requirements.txt
 ```
 
+> Note: On Windows, or inside an activated virtual environment where `python3` is not available, use `python` in the commands below instead.
+
 > Note: Python SDKs older than version 4.1.9 require OpenSSL v1.1. This might not be the default in some newer platforms. In such scenarios, please install the SDK without using the prebuilt wheels
 
-> `python -m pip install couchbase --no-binary couchbase`
+> `python3 -m pip install couchbase --no-binary couchbase`
 
 > Refer to the [instructions in the SDK](https://github.com/couchbase/couchbase-python-client#alternative-installation-methods) for more info.
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ To run this prebuilt project, you will need:
 
 - [Couchbase Capella](https://www.couchbase.com/products/capella/) cluster with [travel-sample](https://docs.couchbase.com/python-sdk/current/ref/travel-app-data-model.html) bucket loaded.
   - To run this tutorial using a self managed Couchbase cluster, please refer to the [appendix](#running-self-managed-couchbase-cluster).
-- [Python](https://www.python.org/downloads/) 3.9 or higher installed
+- [Python](https://www.python.org/downloads/) 3.12 or higher installed
+  - This quickstart is verified in CI and locally with Python 3.12.
   - Ensure that the Python version is [compatible](https://docs.couchbase.com/python-sdk/current/project-docs/compatibility.html#python-version-compat) with the Couchbase SDK.
 - Loading Travel Sample Bucket
   If travel-sample is not loaded in your Capella cluster, you can load it by following the instructions for your Capella Cluster:
@@ -37,11 +38,9 @@ git clone https://github.com/couchbase-examples/python-quickstart.git
 
 The dependencies for the application are specified in the `requirements.txt` file in the source folder. Dependencies can be installed through `pip` the default package manager for Python.
 
-> Note: If your Python is not symbolically linked to python3, you need to run all commands using `python3` instead of `python`.
-
 ```shell
 cd src
-python -m pip install -r requirements.txt
+python3 -m pip install -r requirements.txt
 ```
 
 > Note: Python SDKs older than version 4.1.9 require OpenSSL v1.1. This might not be the default in some newer platforms. In such scenarios, please install the SDK without using the prebuilt wheels
@@ -79,7 +78,7 @@ At this point, we have installed the dependencies, loaded the travel-sample data
 
 ```sh
 cd src
-python app.py
+python3 app.py
 ```
 
 ### Using Docker
@@ -115,7 +114,7 @@ To run the integration tests, use the following commands:
 
 ```sh
 cd src
-python -m pytest
+python3 -m pytest
 ```
 
 ## Appendix

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim-bullseye
+FROM python:3.12-slim-bookworm
 
 WORKDIR /app
 

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,5 +1,5 @@
 couchbase==4.6.1
-flask_restx==1.3.0
+flask_restx==1.3.2
 pytest==9.0.3
 python-dotenv==1.2.2
 requests==2.33.1


### PR DESCRIPTION
## Summary
- bump `flask_restx` from 1.3.0 to 1.3.2
- keep CI/Docker verification on Python 3.12 while documenting the repo prerequisite as Python 3.10+, because the pinned dependency set now bottoms out at Python 3.10
- refresh README command examples to use the standard `python` invocation, with a note for environments that only provide `python3`

## Verification
- dependency metadata check against the pinned packages on PyPI:
  - `couchbase==4.6.1` → `>=3.7`
  - `flask_restx==1.3.2` → `>=3.9`
  - `pytest==9.0.3` → `>=3.10`
  - `python-dotenv==1.2.2` → `>=3.10`
  - `requests==2.33.1` → `>=3.10`
- `cd src && uv venv --seed --python 3.12 ...` ✅
- `cd src && python -m pip install -r requirements.txt` ✅
- follow-up attempt to rerun the live Flask walkthrough against the current local cluster was blocked because the SDK `Cluster.wait_until_ready()` call against `couchbase://127.0.0.1` did not complete in this environment; prior end-to-end walkthrough evidence from 2026-05-01 remains linked below

## Evidence
- prior end-to-end verification from this PR: `tutorial-maintenance/runs/python-quickstart/2026-05-01T163641/`
- follow-up dependency/runtime-floor evidence for this sweep: `tutorial-maintenance/runs/weekly-manifest-maintenance-sweep/2026-05-05T0000Z/subagents/python-pr-followup/pr142/`

## Notes
- The human review feedback about not hard-coding `python3` is reflected in the current README: the command examples now use `python`, with a single note telling users to substitute `python3` if that is what their environment provides.
- I did not make an additional code change in this follow-up because the current branch already matches the requested doc direction.
