### PR TITLE
Bump pytest to 9.1.0

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,5 +1,5 @@
 couchbase==4.6.1
 flask_restx==1.3.2
-pytest==9.0.3
+pytest==9.1.0
 python-dotenv==1.2.2
 requests==2.34.2


### PR DESCRIPTION
## Summary
- bump `pytest` from `9.0.3` to `9.1.0` in `src/requirements.txt`
- rerun the Flask quickstart integration suite and a live Capella-backed walkthrough after the dependency refresh

## Verification
- `cd src && uv venv --python /home/elliot/.pyenv/versions/3.12.13/bin/python --seed --clear .venv`
- `cd src && source .venv/bin/activate && uv pip install -r requirements.txt`
- `cd src && source .venv/bin/activate && python -m pytest -q` → `47 passed in 38.00s` (baseline with app running)
- `cd src && source .venv/bin/activate && python -m pytest -q` → `47 passed in 31.99s` (after the bump, with app running)
- `cd src && source .venv/bin/activate && python -m pip list --outdated --format=json` → `[pytest 9.0.3 -> 9.1.0]` before the bump, `[]` after it
- `cd src && source .venv/bin/activate && uvx pip-audit -r requirements.txt` → `No known vulnerabilities found`
- walkthrough requests captured in `tutorial-maintenance/runs/python-quickstart/2026-06-16T000000/walkthrough.txt`

## Evidence
- Swagger UI loaded successfully at `GET /`.
- `GET /api/v1/airport/list?country=France&limit=2` returned two France airport documents.
- `GET /api/v1/hotel/autocomplete?name=sea` returned expected hotel suggestions including `Seal View` and `Seal Cove Inn`.
- `POST /api/v1/hotel/filter?limit=2&offset=0` with `{"description":"newly renovated"}` returned matching hotel documents.
- Visual proof captured from the running Swagger surface:
  - `tutorial-maintenance/runs/python-quickstart/2026-06-16T000000/screenshots/swagger-ui.png`
  - `tutorial-maintenance/runs/python-quickstart/2026-06-16T000000/swagger-ui.webm`
- `tutorial-maintenance/runs/python-quickstart/2026-06-16T000000/verification.md`

<details><summary>pytest output</summary>

```text
47 passed in 31.99s
```

</details>

## Notes
- No additional pinned dependency updates were available after the `pytest` bump.
- `uvx pip-audit -r requirements.txt` stayed clean before and after the update.
- I reviewed the README/tutorial flow during the walkthrough and did not find new repo-side drift that needed a follow-up change in this branch.
- Separate manifest drift remains in `tutorial-maintenance/tutorials.json`: that record still says Python `3.9+`, while this repo now documents Python `3.10+` and CI runs on Python `3.12`.

## Media evidence
- Auto-attached reviewer-facing media from the local verification artifacts captured during this run.
- This keeps the main PR body self-contained instead of relying on a follow-up comment for visual proof.

![Swagger Ui](https://res.cloudinary.com/dhwqj0ps2/image/upload/v1781575500/pr-evidence/couchbase-examples/python-quickstart/pr-148/swagger-ui.png)

<details><summary>Notes</summary>

- Local artifact path: `tutorial-maintenance/runs/python-quickstart/2026-06-16T000000/screenshots/swagger-ui.png`

</details>

[Swagger Ui](https://res.cloudinary.com/dhwqj0ps2/video/upload/v1781575509/pr-evidence/couchbase-examples/python-quickstart/pr-148/swagger-ui.webm)

<details><summary>Notes</summary>

- Local artifact path: `tutorial-maintenance/runs/python-quickstart/2026-06-16T000000/swagger-ui.webm`

</details>
